### PR TITLE
Add companion window for Package Manager My Assets imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
 
 💡 _Always remove previous plugin version before updating_
 
+## [1.3.0] - 2026-02-13
+
+### Added
+- Add companion window that auto-appears alongside Unity's import dialog, allowing you to redirect any .unitypackage import to a specific folder — works with Package Manager "My Assets" imports, drag-and-drop, and the Assets menu (closes #6)
+
 ## [1.2.1] - 2025-08-15
 
 ### Fixed

--- a/Editor/Package2Folder.cs
+++ b/Editor/Package2Folder.cs
@@ -1,4 +1,4 @@
-﻿// new argument was added in 19.1.4
+// new argument was added in 19.1.4
 
 #if UNITY_2019_3_OR_NEWER
 #define CS_P2F_NEW_ARGUMENT_2
@@ -11,9 +11,11 @@
 #endif
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using UnityEditor;
+using UnityEngine;
 
 namespace CodeStage.PackageToFolder
 {
@@ -64,7 +66,7 @@ namespace CodeStage.PackageToFolder
 				return extractAndPrepareAssetList;
 			}
 		}
-		
+
 		private static FieldInfo destinationAssetPathFieldInfo;
 		private static FieldInfo DestinationAssetPathFieldInfo
 		{
@@ -118,7 +120,64 @@ namespace CodeStage.PackageToFolder
 			}
 		}
 
+		private static Type packageImportType;
+		private static Type PackageImportType
+		{
+			get
+			{
+				if (packageImportType == null)
+					packageImportType = typeof(MenuItem).Assembly.GetType("UnityEditor.PackageImport");
+				return packageImportType;
+			}
+		}
+
+		private static FieldInfo importPackageItemsFieldInfo;
+		private static FieldInfo ImportPackageItemsFieldInfo
+		{
+			get
+			{
+				if (importPackageItemsFieldInfo == null)
+					importPackageItemsFieldInfo = PackageImportType.GetField("m_ImportPackageItems", BindingFlags.NonPublic | BindingFlags.Instance);
+				return importPackageItemsFieldInfo;
+			}
+		}
+
+		private static FieldInfo treeFieldInfo;
+		private static FieldInfo TreeFieldInfo
+		{
+			get
+			{
+				if (treeFieldInfo == null)
+					treeFieldInfo = PackageImportType.GetField("m_Tree", BindingFlags.NonPublic | BindingFlags.Instance);
+				return treeFieldInfo;
+			}
+		}
+
 		#endregion reflection stuff
+
+		///////////////////////////////////////////////////////////////
+		// PackageImport window watcher
+		///////////////////////////////////////////////////////////////
+
+		[InitializeOnLoadMethod]
+		private static void SetupPackageImportWatcher()
+		{
+			EditorApplication.update -= WatchForPackageImportWindows;
+			EditorApplication.update += WatchForPackageImportWindows;
+		}
+
+		private static void WatchForPackageImportWindows()
+		{
+			var windows = Resources.FindObjectsOfTypeAll(PackageImportType);
+			if (windows == null || windows.Length == 0) return;
+
+			foreach (var window in windows)
+			{
+				var editorWindow = window as EditorWindow;
+				if (editorWindow != null)
+					Package2FolderCompanion.ShowForImportWindow(editorWindow);
+			}
+		}
 
 		///////////////////////////////////////////////////////////////
 		// Unity Editor menus integration
@@ -137,7 +196,7 @@ namespace CodeStage.PackageToFolder
 			var packagePath = EditorUtility.OpenFilePanel("Import package ...", "",  "unitypackage");
 			if (string.IsNullOrEmpty(packagePath)) return;
 			if (!File.Exists(packagePath)) return;
-			
+
 			var selectedFolderPath = GetSelectedFolderPath();
 			ImportPackageToFolder(packagePath, selectedFolderPath, true);
 		}
@@ -180,7 +239,7 @@ namespace CodeStage.PackageToFolder
 			{
 #if CS_P2F_NEW_ARGUMENT_2
 				ShowImportPackageWindow(packagePath, assetsItems, packageIconPath, assetOrigin);
-#else	
+#else
 				ShowImportPackageWindow(packagePath, assetsItems, packageIconPath, allowReInstall);
 #endif
 
@@ -192,11 +251,11 @@ namespace CodeStage.PackageToFolder
 			}
 		}
 
-		private static void ChangeAssetItemPath(object assetItem, string selectedFolderPath)
+		public static void ChangeAssetItemPath(object assetItem, string selectedFolderPath)
 		{
 			string destinationPath = (string)DestinationAssetPathFieldInfo.GetValue(assetItem);
 			if (destinationPath.StartsWith("Packages/")) return;
-			
+
 			int firstSlashIndex = destinationPath.IndexOf('/');
 			if (firstSlashIndex >= 0)
 			{
@@ -207,10 +266,10 @@ namespace CodeStage.PackageToFolder
 			{
 				destinationPath = selectedFolderPath + "/" + destinationPath;
 			}
-			
+
 			DestinationAssetPathFieldInfo.SetValue(assetItem, destinationPath);
 		}
-		
+
 #if CS_P2F_NEW_ARGUMENT_2
 		public static void ShowImportPackageWindow(string path, object[] array, string packageIconPath, object assetOrigin = null)
 		{
@@ -269,6 +328,53 @@ namespace CodeStage.PackageToFolder
 		}
 
 		///////////////////////////////////////////////////////////////
+		// PackageImport window helpers
+		///////////////////////////////////////////////////////////////
+
+		internal static object[] GetImportPackageItems(EditorWindow importWindow)
+		{
+			return ImportPackageItemsFieldInfo.GetValue(importWindow) as object[];
+		}
+
+		internal static string[] GetImportItemPaths(EditorWindow importWindow)
+		{
+			var items = GetImportPackageItems(importWindow);
+			if (items == null) return null;
+
+			var paths = new string[items.Length];
+			for (int i = 0; i < items.Length; i++)
+			{
+				paths[i] = (string)DestinationAssetPathFieldInfo.GetValue(items[i]);
+			}
+			return paths;
+		}
+
+		internal static void SetImportWindowFolder(EditorWindow importWindow, string selectedFolderPath, string[] originalPaths)
+		{
+			var items = GetImportPackageItems(importWindow);
+			if (items == null) return;
+
+			// Restore original paths first to avoid stacking folder prefixes
+			if (originalPaths != null)
+			{
+				for (int i = 0; i < items.Length && i < originalPaths.Length; i++)
+				{
+					DestinationAssetPathFieldInfo.SetValue(items[i], originalPaths[i]);
+				}
+			}
+
+			// Apply new folder
+			foreach (var item in items)
+			{
+				ChangeAssetItemPath(item, selectedFolderPath);
+			}
+
+			// Reset tree view to force rebuild
+			TreeFieldInfo.SetValue(importWindow, null);
+			importWindow.Repaint();
+		}
+
+		///////////////////////////////////////////////////////////////
 		// Utility methods
 		///////////////////////////////////////////////////////////////
 
@@ -280,6 +386,112 @@ namespace CodeStage.PackageToFolder
 			var assetGuid = Selection.assetGUIDs[0];
 			var path = AssetDatabase.GUIDToAssetPath(assetGuid);
 			return !Directory.Exists(path) ? null : path;
+		}
+	}
+
+	internal class Package2FolderCompanion : EditorWindow
+	{
+		private static readonly Dictionary<int, Package2FolderCompanion> activeCompanions = new Dictionary<int, Package2FolderCompanion>();
+
+		[SerializeField] private EditorWindow importWindow;
+		[SerializeField] private string[] originalPaths;
+		[SerializeField] private string selectedFolder;
+
+		internal static void ShowForImportWindow(EditorWindow importWindow)
+		{
+			var id = importWindow.GetInstanceID();
+
+			Package2FolderCompanion existing;
+			if (activeCompanions.TryGetValue(id, out existing) && existing != null)
+				return;
+
+			var companion = CreateInstance<Package2FolderCompanion>();
+			companion.importWindow = importWindow;
+			companion.titleContent = new GUIContent("Package2Folder");
+			companion.CacheOriginalPaths();
+			companion.ShowUtility();
+			companion.PositionNearImportWindow();
+			activeCompanions[id] = companion;
+		}
+
+		private void CacheOriginalPaths()
+		{
+			originalPaths = Package2Folder.GetImportItemPaths(importWindow);
+		}
+
+		private void PositionNearImportWindow()
+		{
+			if (importWindow == null) return;
+
+			var importPos = importWindow.position;
+			position = new Rect(
+				importPos.x + importPos.width + 10,
+				importPos.y,
+				220,
+				60
+			);
+		}
+
+		private void OnEnable()
+		{
+			if (importWindow != null)
+				activeCompanions[importWindow.GetInstanceID()] = this;
+		}
+
+		private void Update()
+		{
+			if (importWindow == null)
+			{
+				Close();
+			}
+		}
+
+		private void OnGUI()
+		{
+			if (GUILayout.Button("Import to Folder...", GUILayout.Height(30)))
+			{
+				SelectFolderAndModifyPaths();
+			}
+
+			if (!string.IsNullOrEmpty(selectedFolder))
+			{
+				EditorGUILayout.LabelField("Target: " + selectedFolder, EditorStyles.miniLabel);
+			}
+		}
+
+		private void SelectFolderAndModifyPaths()
+		{
+			var absolutePath = EditorUtility.OpenFolderPanel("Select target folder", "Assets", "");
+			if (string.IsNullOrEmpty(absolutePath)) return;
+
+			absolutePath = absolutePath.Replace('\\', '/');
+			var dataPath = Application.dataPath.Replace('\\', '/');
+
+			string relativePath;
+			if (absolutePath == dataPath)
+			{
+				relativePath = "Assets";
+			}
+			else if (absolutePath.StartsWith(dataPath + "/"))
+			{
+				relativePath = "Assets" + absolutePath.Substring(dataPath.Length);
+			}
+			else
+			{
+				EditorUtility.DisplayDialog("Invalid Folder",
+					"Please select a folder inside the Assets directory.", "OK");
+				return;
+			}
+
+			selectedFolder = relativePath;
+			Package2Folder.SetImportWindowFolder(importWindow, selectedFolder, originalPaths);
+			Repaint();
+		}
+
+		private void OnDestroy()
+		{
+			if (importWindow != null)
+				activeCompanions.Remove(importWindow.GetInstanceID());
 		}
 	}
 }

--- a/Editor/Package2Folder.cs
+++ b/Editor/Package2Folder.cs
@@ -112,8 +112,7 @@ namespace CodeStage.PackageToFolder
 			{
 				if (showImportPackageMethodInfo == null)
 				{
-					var packageImport = typeof(MenuItem).Assembly.GetType("UnityEditor.PackageImport");
-					showImportPackageMethodInfo = packageImport.GetMethod("ShowImportPackage");
+					showImportPackageMethodInfo = PackageImportType.GetMethod("ShowImportPackage");
 				}
 
 				return showImportPackageMethodInfo;
@@ -166,8 +165,13 @@ namespace CodeStage.PackageToFolder
 			EditorApplication.update += WatchForPackageImportWindows;
 		}
 
+		private static double nextWatchTime;
+
 		private static void WatchForPackageImportWindows()
 		{
+			if (EditorApplication.timeSinceStartup < nextWatchTime) return;
+			nextWatchTime = EditorApplication.timeSinceStartup + 0.25;
+
 			var windows = Resources.FindObjectsOfTypeAll(PackageImportType);
 			if (windows == null || windows.Length == 0) return;
 
@@ -253,6 +257,9 @@ namespace CodeStage.PackageToFolder
 
 		public static void ChangeAssetItemPath(object assetItem, string selectedFolderPath)
 		{
+			if (string.IsNullOrEmpty(selectedFolderPath) || !selectedFolderPath.StartsWith("Assets"))
+				throw new ArgumentException("selectedFolderPath must start with 'Assets'", "selectedFolderPath");
+
 			string destinationPath = (string)DestinationAssetPathFieldInfo.GetValue(assetItem);
 			if (destinationPath.StartsWith("Packages/")) return;
 
@@ -392,6 +399,7 @@ namespace CodeStage.PackageToFolder
 	internal class Package2FolderCompanion : EditorWindow
 	{
 		private static readonly Dictionary<int, Package2FolderCompanion> activeCompanions = new Dictionary<int, Package2FolderCompanion>();
+		private static readonly HashSet<int> dismissedImportWindows = new HashSet<int>();
 
 		[SerializeField] private EditorWindow importWindow;
 		[SerializeField] private string[] originalPaths;
@@ -400,6 +408,11 @@ namespace CodeStage.PackageToFolder
 		internal static void ShowForImportWindow(EditorWindow importWindow)
 		{
 			var id = importWindow.GetInstanceID();
+
+			if (dismissedImportWindows.Contains(id))
+				return;
+
+			ClearStaleEntries();
 
 			Package2FolderCompanion existing;
 			if (activeCompanions.TryGetValue(id, out existing) && existing != null)
@@ -412,6 +425,21 @@ namespace CodeStage.PackageToFolder
 			companion.ShowUtility();
 			companion.PositionNearImportWindow();
 			activeCompanions[id] = companion;
+		}
+
+		private static void ClearStaleEntries()
+		{
+			var staleKeys = new List<int>();
+			foreach (var kvp in activeCompanions)
+			{
+				if (kvp.Value == null || kvp.Value.importWindow == null)
+					staleKeys.Add(kvp.Key);
+			}
+			foreach (var key in staleKeys)
+			{
+				activeCompanions.Remove(key);
+				dismissedImportWindows.Remove(key);
+			}
 		}
 
 		private void CacheOriginalPaths()
@@ -463,6 +491,7 @@ namespace CodeStage.PackageToFolder
 		{
 			var absolutePath = EditorUtility.OpenFolderPanel("Select target folder", "Assets", "");
 			if (string.IsNullOrEmpty(absolutePath)) return;
+			if (importWindow == null) return;
 
 			absolutePath = absolutePath.Replace('\\', '/');
 			var dataPath = Application.dataPath.Replace('\\', '/');
@@ -491,7 +520,12 @@ namespace CodeStage.PackageToFolder
 		private void OnDestroy()
 		{
 			if (importWindow != null)
-				activeCompanions.Remove(importWindow.GetInstanceID());
+			{
+				var id = importWindow.GetInstanceID();
+				activeCompanions.Remove(id);
+				// Import window still alive means user dismissed companion manually
+				dismissedImportWindows.Add(id);
+			}
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -34,11 +34,22 @@ Download the latest `.unitypackage` file from the [Releases](https://github.com/
 
 ## How to use
 
-1. Import the package to your project using one of the installation methods above
-2. In the Project window, select the folder where you want to import a package
-3. Use the menu item: `Assets > Import Package > Here...`
-4. Select the `.unitypackage` file you want to import
-5. The package will be imported into the selected folder instead of the project root
+### Option A: Via right-click menu (select folder first)
+
+1. In the Project window, select the folder where you want to import a package
+2. Use the menu item: `Assets > Import Package > Here...`
+3. Select the `.unitypackage` file you want to import
+4. The package will be imported into the selected folder instead of the project root
+
+### Option B: Via companion window (any import method)
+
+Whenever Unity's import dialog opens — whether from **Package Manager > My Assets**, drag-and-drop, or the Assets menu — a small **Package2Folder** utility window automatically appears next to it:
+
+1. Trigger a `.unitypackage` import from any source (e.g. Package Manager "My Assets" tab)
+2. In the companion window that appears, click **"Import to Folder..."**
+3. Select the target folder under Assets/
+4. The import dialog updates to show the new destination paths
+5. Click **Import** in the import dialog as usual
 
 ## Public API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net.codestage.package2folder",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "displayName": "Package2Folder",
   "description": "Unity Editor extension that allows you to import custom packages into the selected Project folder, avoiding your project's root bloating.",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary

- Adds a **Package2Folder companion utility window** that auto-appears alongside Unity's `PackageImport` dialog, enabling folder-targeted imports from **any** source — Package Manager "My Assets", drag-and-drop, or the Assets menu
- Watches for `PackageImport` windows via `EditorApplication.update` and opens a small utility window with an "Import to Folder..." button
- Modifies import item destination paths in-place via reflection, resets the tree view, and repaints the dialog so the user sees updated paths before clicking Import
- Caches original paths to support re-selecting a different target folder without stacking prefixes
- Survives domain reloads via `[SerializeField]` fields and `OnEnable` re-registration
- Bumps version to **1.3.0**, updates CHANGELOG and README with new user flow

Closes #6

## Test plan

- [x] Open Package Manager > My Assets > Download + Import any asset
- [x] Verify companion window appears alongside PackageImport dialog
- [x] Click "Import to Folder...", select a subfolder under Assets/
- [x] Verify paths in import dialog update to show selected folder prefix
- [x] Click Import, verify assets land in selected folder
- [x] Test existing "Assets > Import Package > Here..." still works unchanged
- [x] Test drag-drop .unitypackage also triggers companion window
- [x] Test canceling folder picker doesn't break anything
- [x] Test closing companion window doesn't affect normal import
- [x] Test closing PackageImport auto-closes companion
- [x] Test selecting folder outside Assets/ shows error dialog
- [x] Test re-selecting a different folder doesn't stack prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companion window now auto-appears during .unitypackage imports (including Package Manager "My Assets", drag-and-drop, and Assets menu) to redirect imports into a chosen folder.
* **Documentation**
  * Updated docs with two explicit import workflows (right-click folder option and companion-window path) and expanded Public API examples.
* **Chores**
  * Release bumped to v1.3.0 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->