### PR TITLE
Add default import folder setting (closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.
 
 💡 _Always remove previous plugin version before updating_
 
+## [Unreleased]
+
+### Added
+- Add default import folder setting (Edit > Preferences > Package2Folder): when set, the companion window redirects package import dialogs to that folder, a Restore Original Paths button undoes it for a single import, and folders picked explicitly via Import Package > Here... still win (closes #9)
+
 ## [1.3.0] - 2026-02-13
 
 ### Added

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodeStage.PackageToFolder.Editor.Tests")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99cc8cb676ad4cb8bf07c0b9cc9375d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Package2Folder.cs
+++ b/Editor/Package2Folder.cs
@@ -173,7 +173,27 @@ namespace CodeStage.PackageToFolder
 			nextWatchTime = EditorApplication.timeSinceStartup + 0.25;
 
 			var windows = Resources.FindObjectsOfTypeAll(PackageImportType);
-			if (windows == null || windows.Length == 0) return;
+			if (windows == null || windows.Length == 0)
+			{
+				// No import windows left: any not-yet-consumed explicit-import
+				// state belongs to windows that never got a companion, and kept
+				// dismiss marks could block a companion for a recycled window ID.
+				ClearPendingImportState();
+				Package2FolderCompanion.ClearDismissedWindows();
+				return;
+			}
+
+			// Drop bookkeeping for registered windows that closed before a companion
+			// consumed it, so a recycled instance ID can't inherit another window's state.
+			if (HasPendingImportState)
+			{
+				var liveIds = new HashSet<int>();
+				foreach (var window in windows)
+				{
+					liveIds.Add(window.GetInstanceID());
+				}
+				PruneStalePendingImportState(liveIds);
+			}
 
 			foreach (var window in windows)
 			{
@@ -215,7 +235,9 @@ namespace CodeStage.PackageToFolder
 		/// <param name="packagePath">Native path to the package.</param>
 		/// <param name="selectedFolderPath">Path to the target folder where you wish to import package into.
 		/// Relative to the project folder (should start with 'Assets')</param>
-		/// <param name="interactive">If true - imports using standard import window, otherwise does this silently.</param>
+		/// <param name="interactive">If true - imports using standard import window, otherwise does this silently.
+		/// The companion window will not auto-apply the configured default folder to an import window
+		/// opened this way, since the folder was chosen explicitly.</param>
 		/// <param name="assetOrigin">An optional UnityEditor.AssetOrigin object which Unity from version 2023+ uses internally to store the source of the imported asset inside the meta file.</param>
 		public static void ImportPackageToFolder(string packagePath, string selectedFolderPath, bool interactive, object assetOrigin = null)
 		{
@@ -234,6 +256,12 @@ namespace CodeStage.PackageToFolder
 
 			if (assetsItems == null) return;
 
+			// Captured before re-pathing so the companion can restore the package's
+			// true original paths instead of the already-prefixed ones.
+			string[] pristinePaths = null;
+			if (interactive)
+				pristinePaths = GetItemDestinationPaths(assetsItems);
+
 			foreach (object item in assetsItems)
 			{
 				ChangeAssetItemPath(item, selectedFolderPath);
@@ -241,12 +269,13 @@ namespace CodeStage.PackageToFolder
 
 			if (interactive)
 			{
+				var knownWindowIds = GetPackageImportWindowIds();
 #if CS_P2F_NEW_ARGUMENT_2
 				ShowImportPackageWindow(packagePath, assetsItems, packageIconPath, assetOrigin);
 #else
 				ShowImportPackageWindow(packagePath, assetsItems, packageIconPath, allowReInstall);
 #endif
-
+				RegisterNewImportWindows(knownWindowIds, pristinePaths);
 			}
 			else
 			{
@@ -335,6 +364,91 @@ namespace CodeStage.PackageToFolder
 		}
 
 		///////////////////////////////////////////////////////////////
+		// Explicit-import bookkeeping (default folder suppression)
+		///////////////////////////////////////////////////////////////
+
+		// State is keyed by PackageImport window instance ID so that concurrent
+		// or aborted imports can't leak suppression onto unrelated windows.
+		private static readonly HashSet<int> autoApplySuppressedWindows = new HashSet<int>();
+		private static readonly Dictionary<int, string[]> pendingPristinePaths = new Dictionary<int, string[]>();
+
+		/// <summary>
+		/// Marks an import window as opened through an explicit ImportPackageToFolder call:
+		/// the companion must not auto-apply the default folder to it, and should use
+		/// <paramref name="pristinePaths"/> (captured before re-pathing) as the restore baseline.
+		/// </summary>
+		internal static void RegisterExplicitImportWindow(int windowInstanceId, string[] pristinePaths)
+		{
+			autoApplySuppressedWindows.Add(windowInstanceId);
+			if (pristinePaths != null)
+				pendingPristinePaths[windowInstanceId] = pristinePaths;
+		}
+
+		/// <summary>
+		/// Returns true exactly once per window registered via RegisterExplicitImportWindow.
+		/// </summary>
+		internal static bool ConsumeAutoApplySuppression(int windowInstanceId)
+		{
+			return autoApplySuppressedWindows.Remove(windowInstanceId);
+		}
+
+		/// <summary>
+		/// Hands out the pristine destination paths captured for the window, at most once.
+		/// </summary>
+		internal static bool TryTakePristinePaths(int windowInstanceId, out string[] pristinePaths)
+		{
+			if (pendingPristinePaths.TryGetValue(windowInstanceId, out pristinePaths))
+			{
+				pendingPristinePaths.Remove(windowInstanceId);
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Drops all pending explicit-import state; called when no PackageImport windows exist.
+		/// </summary>
+		internal static void ClearPendingImportState()
+		{
+			autoApplySuppressedWindows.Clear();
+			pendingPristinePaths.Clear();
+		}
+
+		internal static bool HasPendingImportState
+		{
+			get { return autoApplySuppressedWindows.Count > 0 || pendingPristinePaths.Count > 0; }
+		}
+
+		/// <summary>
+		/// Removes registrations for windows no longer alive, so a later window with a
+		/// recycled instance ID cannot pick up another window's suppression or paths.
+		/// </summary>
+		internal static void PruneStalePendingImportState(HashSet<int> liveWindowIds)
+		{
+			autoApplySuppressedWindows.RemoveWhere(id => !liveWindowIds.Contains(id));
+
+			if (pendingPristinePaths.Count == 0) return;
+
+			List<int> staleIds = null;
+			foreach (var pending in pendingPristinePaths)
+			{
+				if (liveWindowIds.Contains(pending.Key)) continue;
+
+				if (staleIds == null)
+					staleIds = new List<int>();
+				staleIds.Add(pending.Key);
+			}
+
+			if (staleIds == null) return;
+
+			foreach (var id in staleIds)
+			{
+				pendingPristinePaths.Remove(id);
+			}
+		}
+
+		///////////////////////////////////////////////////////////////
 		// PackageImport window helpers
 		///////////////////////////////////////////////////////////////
 
@@ -348,12 +462,65 @@ namespace CodeStage.PackageToFolder
 			var items = GetImportPackageItems(importWindow);
 			if (items == null) return null;
 
+			return GetItemDestinationPaths(items);
+		}
+
+		private static string[] GetItemDestinationPaths(object[] items)
+		{
 			var paths = new string[items.Length];
 			for (int i = 0; i < items.Length; i++)
 			{
 				paths[i] = (string)DestinationAssetPathFieldInfo.GetValue(items[i]);
 			}
 			return paths;
+		}
+
+		private static void RestoreItemPaths(object[] items, string[] originalPaths)
+		{
+			for (int i = 0; i < items.Length && i < originalPaths.Length; i++)
+			{
+				DestinationAssetPathFieldInfo.SetValue(items[i], originalPaths[i]);
+			}
+		}
+
+		private static HashSet<int> GetPackageImportWindowIds()
+		{
+			var ids = new HashSet<int>();
+			var windows = Resources.FindObjectsOfTypeAll(PackageImportType);
+			if (windows == null) return ids;
+
+			foreach (var window in windows)
+			{
+				ids.Add(window.GetInstanceID());
+			}
+			return ids;
+		}
+
+		private static void RegisterNewImportWindows(HashSet<int> knownWindowIds, string[] pristinePaths)
+		{
+			var windows = Resources.FindObjectsOfTypeAll(PackageImportType);
+			if (windows == null) return;
+
+			foreach (var window in windows)
+			{
+				var id = window.GetInstanceID();
+				if (!knownWindowIds.Contains(id))
+					RegisterExplicitImportWindow(id, pristinePaths);
+			}
+		}
+
+		/// <summary>
+		/// Resets all import item destinations to <paramref name="originalPaths"/> and rebuilds the window's tree.
+		/// </summary>
+		internal static void RestoreImportWindowPaths(EditorWindow importWindow, string[] originalPaths)
+		{
+			var items = GetImportPackageItems(importWindow);
+			if (items == null || originalPaths == null) return;
+
+			RestoreItemPaths(items, originalPaths);
+
+			TreeFieldInfo.SetValue(importWindow, null);
+			importWindow.Repaint();
 		}
 
 		internal static void SetImportWindowFolder(EditorWindow importWindow, string selectedFolderPath, string[] originalPaths)
@@ -363,12 +530,7 @@ namespace CodeStage.PackageToFolder
 
 			// Restore original paths first to avoid stacking folder prefixes
 			if (originalPaths != null)
-			{
-				for (int i = 0; i < items.Length && i < originalPaths.Length; i++)
-				{
-					DestinationAssetPathFieldInfo.SetValue(items[i], originalPaths[i]);
-				}
-			}
+				RestoreItemPaths(items, originalPaths);
 
 			// Apply new folder
 			foreach (var item in items)
@@ -405,6 +567,15 @@ namespace CodeStage.PackageToFolder
 		[SerializeField] private string[] originalPaths;
 		[SerializeField] private string selectedFolder;
 
+		/// <summary>
+		/// Forgets manual dismissals; called when no PackageImport windows exist, since a kept
+		/// mark could otherwise block the companion for an unrelated window with a recycled ID.
+		/// </summary>
+		internal static void ClearDismissedWindows()
+		{
+			dismissedImportWindows.Clear();
+		}
+
 		internal static void ShowForImportWindow(EditorWindow importWindow)
 		{
 			var id = importWindow.GetInstanceID();
@@ -421,10 +592,23 @@ namespace CodeStage.PackageToFolder
 			var companion = CreateInstance<Package2FolderCompanion>();
 			companion.importWindow = importWindow;
 			companion.titleContent = new GUIContent("Package2Folder");
-			companion.CacheOriginalPaths();
+
+			// For explicit ImportPackageToFolder imports the window's current paths already
+			// carry the chosen folder, so the restore baseline comes from the pristine
+			// paths captured before re-pathing.
+			string[] pristinePaths;
+			if (Package2Folder.TryTakePristinePaths(id, out pristinePaths))
+				companion.originalPaths = pristinePaths;
+			else
+				companion.CacheOriginalPaths();
+
 			companion.ShowUtility();
 			companion.PositionNearImportWindow();
 			activeCompanions[id] = companion;
+
+			var suppressAutoApply = Package2Folder.ConsumeAutoApplySuppression(id);
+			if (!suppressAutoApply && Package2FolderSettings.HasDefaultFolder)
+				companion.ApplyFolder(Package2FolderSettings.DefaultFolder);
 		}
 
 		private static void ClearStaleEntries()
@@ -484,28 +668,55 @@ namespace CodeStage.PackageToFolder
 			if (!string.IsNullOrEmpty(selectedFolder))
 			{
 				EditorGUILayout.LabelField("Target: " + selectedFolder, EditorStyles.miniLabel);
+
+				if (GUILayout.Button("Restore Original Paths"))
+				{
+					RestoreOriginalPaths();
+				}
 			}
+		}
+
+		/// <summary>
+		/// Redirects all import destinations to <paramref name="folderPath"/> (must be under Assets).
+		/// </summary>
+		internal void ApplyFolder(string folderPath)
+		{
+			if (importWindow == null) return;
+
+			selectedFolder = folderPath;
+			Package2Folder.SetImportWindowFolder(importWindow, selectedFolder, originalPaths);
+			UpdateHeight();
+			Repaint();
+		}
+
+		/// <summary>
+		/// Puts all import destinations back to the paths cached when the companion attached.
+		/// </summary>
+		private void RestoreOriginalPaths()
+		{
+			if (importWindow == null) return;
+
+			selectedFolder = null;
+			Package2Folder.RestoreImportWindowPaths(importWindow, originalPaths);
+			UpdateHeight();
+			Repaint();
+		}
+
+		private void UpdateHeight()
+		{
+			var height = string.IsNullOrEmpty(selectedFolder) ? 60 : 92;
+			position = new Rect(position.x, position.y, position.width, height);
 		}
 
 		private void SelectFolderAndModifyPaths()
 		{
-			var absolutePath = EditorUtility.OpenFolderPanel("Select target folder", "Assets", "");
+			var startFolder = Package2FolderSettings.HasDefaultFolder ? Package2FolderSettings.DefaultFolder : "Assets";
+			var absolutePath = EditorUtility.OpenFolderPanel("Select target folder", startFolder, "");
 			if (string.IsNullOrEmpty(absolutePath)) return;
 			if (importWindow == null) return;
 
-			absolutePath = absolutePath.Replace('\\', '/');
-			var dataPath = Application.dataPath.Replace('\\', '/');
-
 			string relativePath;
-			if (absolutePath == dataPath)
-			{
-				relativePath = "Assets";
-			}
-			else if (absolutePath.StartsWith(dataPath + "/"))
-			{
-				relativePath = "Assets" + absolutePath.Substring(dataPath.Length);
-			}
-			else
+			if (!Package2FolderSettings.TryGetProjectRelativeFolder(absolutePath, out relativePath))
 			{
 				EditorUtility.DisplayDialog("Invalid Folder",
 					"Please select a folder inside the Assets directory.", "OK");
@@ -514,6 +725,7 @@ namespace CodeStage.PackageToFolder
 
 			selectedFolder = relativePath;
 			Package2Folder.SetImportWindowFolder(importWindow, selectedFolder, originalPaths);
+			UpdateHeight();
 			Repaint();
 		}
 

--- a/Editor/Package2FolderSettings.cs
+++ b/Editor/Package2FolderSettings.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace CodeStage.PackageToFolder
+{
+	/// <summary>
+	/// Per-user Package2Folder settings (EditorPrefs-backed) and their Preferences UI.
+	/// </summary>
+	internal static class Package2FolderSettings
+	{
+		/// <summary>
+		/// EditorPrefs key holding the default import folder.
+		/// </summary>
+		internal const string DefaultFolderPrefsKey = "CodeStage.Package2Folder.DefaultFolder";
+
+		private static string invalidFolderMessage;
+
+		/// <summary>
+		/// Project-relative folder ("Assets" or below) applied to new import dialogs by default.
+		/// Empty string when unset; setting an empty or null value clears it; setting an
+		/// invalid path throws ArgumentException. A stored invalid value reads as unset.
+		/// </summary>
+		internal static string DefaultFolder
+		{
+			get
+			{
+				var stored = NormalizeFolderPath(EditorPrefs.GetString(DefaultFolderPrefsKey, string.Empty));
+				return IsValidProjectFolder(stored) ? stored : string.Empty;
+			}
+			set
+			{
+				var normalized = NormalizeFolderPath(value);
+				if (normalized.Length == 0)
+				{
+					EditorPrefs.DeleteKey(DefaultFolderPrefsKey);
+					return;
+				}
+
+				if (!IsValidProjectFolder(normalized))
+					throw new ArgumentException("Default folder must be 'Assets' or a folder under it", "value");
+
+				EditorPrefs.SetString(DefaultFolderPrefsKey, normalized);
+			}
+		}
+
+		/// <summary>
+		/// True when a valid default folder is configured.
+		/// </summary>
+		internal static bool HasDefaultFolder
+		{
+			get { return DefaultFolder.Length > 0; }
+		}
+
+		/// <summary>
+		/// Converts backslashes to slashes and trims whitespace and trailing slashes; null becomes an empty string.
+		/// </summary>
+		internal static string NormalizeFolderPath(string rawPath)
+		{
+			if (string.IsNullOrEmpty(rawPath)) return string.Empty;
+
+			var normalized = rawPath.Replace('\\', '/').Trim();
+			while (normalized.EndsWith("/"))
+				normalized = normalized.Substring(0, normalized.Length - 1);
+
+			return normalized;
+		}
+
+		/// <summary>
+		/// True only for "Assets" itself or a path under "Assets/" (case-sensitive).
+		/// </summary>
+		internal static bool IsValidProjectFolder(string folderPath)
+		{
+			if (string.IsNullOrEmpty(folderPath)) return false;
+			return folderPath == "Assets" || folderPath.StartsWith("Assets/", StringComparison.Ordinal);
+		}
+
+		/// <summary>
+		/// Converts an absolute path inside the current project's Assets directory
+		/// to its "Assets/..." form; returns false for paths outside it.
+		/// </summary>
+		internal static bool TryGetProjectRelativeFolder(string absolutePath, out string projectRelativePath)
+		{
+			projectRelativePath = null;
+			if (string.IsNullOrEmpty(absolutePath)) return false;
+
+			var normalized = absolutePath.Replace('\\', '/');
+			var dataPath = Application.dataPath.Replace('\\', '/');
+
+			if (normalized == dataPath)
+			{
+				projectRelativePath = "Assets";
+				return true;
+			}
+
+			if (normalized.StartsWith(dataPath + "/", StringComparison.Ordinal))
+			{
+				projectRelativePath = "Assets" + normalized.Substring(dataPath.Length);
+				return true;
+			}
+
+			return false;
+		}
+
+		///////////////////////////////////////////////////////////////
+		// Preferences UI
+		///////////////////////////////////////////////////////////////
+
+		[SettingsProvider]
+		private static SettingsProvider CreateSettingsProvider()
+		{
+			return new SettingsProvider("Preferences/Package2Folder", SettingsScope.User)
+			{
+				guiHandler = context => DrawPreferencesGUI(),
+				keywords = new HashSet<string> { "package", "import", "folder", "default", "Package2Folder" }
+			};
+		}
+
+		private static void DrawPreferencesGUI()
+		{
+			EditorGUILayout.Space();
+
+			EditorGUILayout.BeginHorizontal();
+
+			var current = DefaultFolder;
+			var entered = EditorGUILayout.DelayedTextField(new GUIContent("Default import folder",
+				"Folder to pre-select in the package import dialog. Use 'Assets' or a folder under it, like Assets/ThirdParty."),
+				current);
+
+			var browseClicked = GUILayout.Button("Browse...", GUILayout.Width(70));
+			var clearClicked = GUILayout.Button("Clear", GUILayout.Width(50));
+
+			EditorGUILayout.EndHorizontal();
+
+			// Modal dialogs must not open while a layout group is still on the stack.
+			if (browseClicked)
+			{
+				BrowseForDefaultFolder();
+			}
+			else if (clearClicked)
+			{
+				DefaultFolder = null;
+				invalidFolderMessage = null;
+				GUI.FocusControl(null);
+			}
+			else if (entered != current)
+			{
+				TrySetDefaultFolder(entered);
+			}
+
+			if (!string.IsNullOrEmpty(invalidFolderMessage))
+				EditorGUILayout.HelpBox(invalidFolderMessage, MessageType.Warning);
+
+			if (HasDefaultFolder)
+				EditorGUILayout.HelpBox("New package import dialogs will target '" + DefaultFolder +
+					"'. To undo it for one import, use the Restore Original Paths button in the companion window.",
+					MessageType.Info);
+		}
+
+		private static void TrySetDefaultFolder(string rawValue)
+		{
+			var normalized = NormalizeFolderPath(rawValue);
+			if (normalized.Length == 0)
+			{
+				DefaultFolder = null;
+				invalidFolderMessage = null;
+				return;
+			}
+
+			if (!IsValidProjectFolder(normalized))
+			{
+				invalidFolderMessage = "The folder must be 'Assets' or a path under it, like Assets/ThirdParty.";
+				return;
+			}
+
+			DefaultFolder = normalized;
+			invalidFolderMessage = null;
+		}
+
+		private static void BrowseForDefaultFolder()
+		{
+			var startFolder = HasDefaultFolder ? DefaultFolder : "Assets";
+			var absolutePath = EditorUtility.OpenFolderPanel("Select default import folder", startFolder, "");
+			if (string.IsNullOrEmpty(absolutePath)) return;
+
+			string relativePath;
+			if (TryGetProjectRelativeFolder(absolutePath, out relativePath))
+			{
+				DefaultFolder = relativePath;
+				invalidFolderMessage = null;
+				GUI.FocusControl(null);
+			}
+			else
+			{
+				invalidFolderMessage = "This folder is outside the project. Pick one inside the Assets directory.";
+			}
+		}
+	}
+}

--- a/Editor/Package2FolderSettings.cs.meta
+++ b/Editor/Package2FolderSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed6b57a09465498b853d6302c647bdad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Whenever Unity's import dialog opens — whether from **Package Manager > My Ass
 4. The import dialog updates to show the new destination paths
 5. Click **Import** in the import dialog as usual
 
+### Setting a default folder
+
+If your packages usually land in the same folder, set it once in `Edit > Preferences > Package2Folder` (for example, `Assets/ThirdParty`).
+
+With a default folder set, the companion window redirects import paths to it as soon as Unity's import dialog opens. The window shows the current target and a **Restore Original Paths** button for cases when one particular package should stay where it was. The folder picker also starts at the default folder.
+
+Imports started via `Assets > Import Package > Here...` are not affected: the folder you select there always wins over the default.
+
 ## Public API
 
 The package exposes a public API that allows you to import packages programmatically:

--- a/Tests/Editor/DefaultFolderSettingsTests.cs
+++ b/Tests/Editor/DefaultFolderSettingsTests.cs
@@ -1,0 +1,191 @@
+#if HAS_TEST_FRAMEWORK
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace CodeStage.PackageToFolder.Tests
+{
+	public class DefaultFolderSettingsTests
+	{
+		private bool hadStoredValue;
+		private string storedValue;
+
+		[SetUp]
+		public void SetUp()
+		{
+			hadStoredValue = EditorPrefs.HasKey(Package2FolderSettings.DefaultFolderPrefsKey);
+			if (hadStoredValue)
+				storedValue = EditorPrefs.GetString(Package2FolderSettings.DefaultFolderPrefsKey);
+
+			EditorPrefs.DeleteKey(Package2FolderSettings.DefaultFolderPrefsKey);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			if (hadStoredValue)
+				EditorPrefs.SetString(Package2FolderSettings.DefaultFolderPrefsKey, storedValue);
+			else
+				EditorPrefs.DeleteKey(Package2FolderSettings.DefaultFolderPrefsKey);
+
+			Package2Folder.ClearPendingImportState();
+		}
+
+		[Test]
+		public void NormalizeFolderPath_ConvertsBackslashesToForwardSlashes()
+		{
+			Assert.AreEqual("Assets/Sub/Deep", Package2FolderSettings.NormalizeFolderPath("Assets\\Sub\\Deep"));
+		}
+
+		[Test]
+		public void NormalizeFolderPath_TrimsWhitespaceAndTrailingSlashes()
+		{
+			Assert.AreEqual("Assets/Sub", Package2FolderSettings.NormalizeFolderPath("  Assets/Sub/  "));
+			Assert.AreEqual("Assets", Package2FolderSettings.NormalizeFolderPath("Assets/"));
+		}
+
+		[Test]
+		public void NormalizeFolderPath_NullOrEmpty_ReturnsEmpty()
+		{
+			Assert.AreEqual(string.Empty, Package2FolderSettings.NormalizeFolderPath(null));
+			Assert.AreEqual(string.Empty, Package2FolderSettings.NormalizeFolderPath(""));
+			Assert.AreEqual(string.Empty, Package2FolderSettings.NormalizeFolderPath("   "));
+		}
+
+		[TestCase("Assets", true)]
+		[TestCase("Assets/ThirdParty", true)]
+		[TestCase("Assets/Third Party/Sub", true)]
+		[TestCase("", false)]
+		[TestCase(null, false)]
+		[TestCase("Packages/Foo", false)]
+		[TestCase("AssetsFoo", false)]
+		[TestCase("assets/foo", false)]
+		public void IsValidProjectFolder_ChecksAssetsPrefix(string path, bool expected)
+		{
+			Assert.AreEqual(expected, Package2FolderSettings.IsValidProjectFolder(path));
+		}
+
+		[Test]
+		public void DefaultFolder_SetAndGet_ReturnsNormalizedValue()
+		{
+			Package2FolderSettings.DefaultFolder = "Assets\\External\\";
+
+			Assert.AreEqual("Assets/External", Package2FolderSettings.DefaultFolder);
+			Assert.IsTrue(Package2FolderSettings.HasDefaultFolder);
+			Assert.AreEqual("Assets/External", EditorPrefs.GetString(Package2FolderSettings.DefaultFolderPrefsKey));
+		}
+
+		[Test]
+		public void DefaultFolder_SetEmpty_ClearsStoredValue()
+		{
+			Package2FolderSettings.DefaultFolder = "Assets/External";
+			Package2FolderSettings.DefaultFolder = "";
+
+			Assert.IsFalse(EditorPrefs.HasKey(Package2FolderSettings.DefaultFolderPrefsKey));
+			Assert.IsFalse(Package2FolderSettings.HasDefaultFolder);
+			Assert.AreEqual(string.Empty, Package2FolderSettings.DefaultFolder);
+		}
+
+		[Test]
+		public void DefaultFolder_SetNull_ClearsStoredValue()
+		{
+			Package2FolderSettings.DefaultFolder = "Assets/External";
+			Package2FolderSettings.DefaultFolder = null;
+
+			Assert.IsFalse(EditorPrefs.HasKey(Package2FolderSettings.DefaultFolderPrefsKey));
+			Assert.IsFalse(Package2FolderSettings.HasDefaultFolder);
+		}
+
+		[Test]
+		public void DefaultFolder_SetInvalid_ThrowsAndKeepsPreviousValue()
+		{
+			Package2FolderSettings.DefaultFolder = "Assets/External";
+
+			Assert.Throws<ArgumentException>(() => Package2FolderSettings.DefaultFolder = "Packages/Nope");
+			Assert.AreEqual("Assets/External", Package2FolderSettings.DefaultFolder);
+		}
+
+		[Test]
+		public void DefaultFolder_StoredInvalidValue_TreatedAsUnset()
+		{
+			EditorPrefs.SetString(Package2FolderSettings.DefaultFolderPrefsKey, "NotAssetsRelative");
+
+			Assert.AreEqual(string.Empty, Package2FolderSettings.DefaultFolder);
+			Assert.IsFalse(Package2FolderSettings.HasDefaultFolder);
+		}
+
+		[Test]
+		public void AutoApplySuppression_ConsumedExactlyOncePerWindow()
+		{
+			Package2Folder.RegisterExplicitImportWindow(101, null);
+
+			Assert.IsTrue(Package2Folder.ConsumeAutoApplySuppression(101));
+			Assert.IsFalse(Package2Folder.ConsumeAutoApplySuppression(101));
+		}
+
+		[Test]
+		public void AutoApplySuppression_ScopedToWindowId()
+		{
+			Package2Folder.RegisterExplicitImportWindow(201, null);
+
+			Assert.IsFalse(Package2Folder.ConsumeAutoApplySuppression(202));
+			Assert.IsTrue(Package2Folder.ConsumeAutoApplySuppression(201));
+		}
+
+		[Test]
+		public void AutoApplySuppression_FalseWhenNotRequested()
+		{
+			Assert.IsFalse(Package2Folder.ConsumeAutoApplySuppression(999));
+		}
+
+		[Test]
+		public void PristinePaths_TakenExactlyOnce()
+		{
+			var paths = new[] { "Assets/Sub/File.txt" };
+			Package2Folder.RegisterExplicitImportWindow(301, paths);
+
+			string[] taken;
+			Assert.IsTrue(Package2Folder.TryTakePristinePaths(301, out taken));
+			CollectionAssert.AreEqual(paths, taken);
+			Assert.IsFalse(Package2Folder.TryTakePristinePaths(301, out taken));
+		}
+
+		[Test]
+		public void PristinePaths_AbsentForUnknownWindow()
+		{
+			string[] taken;
+			Assert.IsFalse(Package2Folder.TryTakePristinePaths(302, out taken));
+			Assert.IsNull(taken);
+		}
+
+		[Test]
+		public void ClearPendingImportState_DropsSuppressionAndPaths()
+		{
+			Package2Folder.RegisterExplicitImportWindow(401, new[] { "Assets/File.txt" });
+
+			Package2Folder.ClearPendingImportState();
+
+			string[] taken;
+			Assert.IsFalse(Package2Folder.ConsumeAutoApplySuppression(401));
+			Assert.IsFalse(Package2Folder.TryTakePristinePaths(401, out taken));
+		}
+
+		[Test]
+		public void PruneStalePendingImportState_DropsOnlyClosedWindows()
+		{
+			Package2Folder.RegisterExplicitImportWindow(501, new[] { "Assets/A.txt" });
+			Package2Folder.RegisterExplicitImportWindow(502, new[] { "Assets/B.txt" });
+
+			Package2Folder.PruneStalePendingImportState(new HashSet<int> { 502 });
+
+			string[] taken;
+			Assert.IsFalse(Package2Folder.ConsumeAutoApplySuppression(501));
+			Assert.IsFalse(Package2Folder.TryTakePristinePaths(501, out taken));
+			Assert.IsTrue(Package2Folder.ConsumeAutoApplySuppression(502));
+			Assert.IsTrue(Package2Folder.TryTakePristinePaths(502, out taken));
+			CollectionAssert.AreEqual(new[] { "Assets/B.txt" }, taken);
+		}
+	}
+}
+#endif

--- a/Tests/Editor/DefaultFolderSettingsTests.cs.meta
+++ b/Tests/Editor/DefaultFolderSettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ab53301c92d4d4f81a5b9b1a3a27c79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/ImportPackageToFolderTests.cs
+++ b/Tests/Editor/ImportPackageToFolderTests.cs
@@ -14,6 +14,7 @@ namespace CodeStage.PackageToFolder.Tests
 		private const string TestAssetContent = "This is a test asset for Package2Folder testing";
 		private const string TestFolderName = "Package2FolderTest";
 		private const string ImportTargetFolder = "ImportedAssets";
+		private const double ImportTimeoutSeconds = 60;
 		
 		private string testAssetPath;
 		private string testFolderPath;
@@ -93,9 +94,19 @@ namespace CodeStage.PackageToFolder.Tests
 			}
 			
 			Package2Folder.ImportPackageToFolder(tempPackagePath, importTargetPath, false);
-			
+
 			AssetDatabase.Refresh();
-			yield return null;
+
+			// Silent import completes asynchronously on some Unity versions (observed on 6000.1+),
+			// so wait for the imported file instead of a fixed number of frames.
+			string expectedImportedAssetPath = Path.Combine(importTargetPath, TestFolderName, TestAssetName);
+			double deadline = EditorApplication.timeSinceStartup + ImportTimeoutSeconds;
+			while (!File.Exists(expectedImportedAssetPath) && EditorApplication.timeSinceStartup < deadline)
+			{
+				yield return null;
+			}
+
+			AssetDatabase.Refresh();
 			yield return null;
 		}
 


### PR DESCRIPTION
Closes #9

## What this adds

A default import folder for Package2Folder, set once in `Edit > Preferences > Package2Folder`:

- When a package import dialog opens, the companion window redirects all import paths to the default folder and shows a "Restore Original Paths" button to undo it for that one import.
- The companion's folder picker starts at the default folder.
- Folders chosen explicitly (via `Assets > Import Package > Here...` or the public `ImportPackageToFolder` API) always win: those windows are registered by instance ID and the companion skips the auto-apply for them.

## Design notes

- The setting is per user (EditorPrefs, `SettingsScope.User`), matching the request in #9 ("I always have one folder for external assets"). Confirmed with the owner before implementation, as was auto-apply on dialog open: the issue asks for the folder to be "selected by default".
- Explicit-import state (suppression plus pristine pre-redirect paths) is keyed by PackageImport window instance ID: registered by diffing window IDs around the show call, consumed once by the companion, pruned against live windows on every watcher tick, and cleared when no import windows remain. This also fixes a pre-existing flaw where a companion attached to a `Here...` import cached already-redirected paths as its restore baseline, so re-picking a folder could stack prefixes.
- Two more pre-existing problems fixed on the way, both directly under the new feature: `dismissedImportWindows` entries could permanently block companions for recycled window IDs (now cleared once the last import window closes), and `TestSilentImportPackageToFolder` was timing-flaky on Unity 6000.1+ because the silent import completes asynchronously (the test now waits for the imported file, 60 s cap; a clean-master baseline run proved the flakiness predates this PR).

## Rejected alternatives

- Project Settings scope (per-project asset): shares the convention with a team, but a tool package would write a committed file into consumer projects, and it does not match the per-user workflow described in the issue.
- Enabling `Import Package > Here...` with no selection as a fallback to the default: muddies the menu's "here means the selected folder" meaning; the companion already covers double-click, Package Manager and Asset Store flows.
- A public settings API: kept internal (`InternalsVisibleTo` for the test assembly only) to leave the public surface unchanged.

## Decisions made autonomously

- Base branch `master`: auto-detect suggested a nonexistent `main`; PR #8 set the precedent.
- Tier "standard" instead of the heuristic's "trivial": a new persisted setting, a Preferences UI and interop wiring is more than a copy change.
- No version bump: the repo uses dedicated "Increment version" commits.
- The flaky pre-existing test is fixed in this PR because the test gate cannot run green honestly otherwise.
- The per-window bookkeeping redesign came out of review pass 1, where three of five reviewers independently converged on the suppression race and leak.
- Documented limitation, left as is: a domain reload landing in the quarter-second between showing an explicit import dialog and the companion attaching resets the static bookkeeping, so the default could win over an explicit choice in that narrow race. The existing companion bookkeeping has the same reload semantics.

## Testing

24/24 EditMode tests green on Unity 6000.1.0f1 in batchmode, including 23 new unit tests for normalization, validation, the EditorPrefs roundtrip, and per-window suppression, pristine-path and pruning behavior. TDD order was kept: the new suite first ran red against stubs. Not covered, since it needs a real PackageImport window: the companion's interactive auto-apply and restore UI path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable default import folder under **Edit > Preferences > Package2Folder**.
  - Package imports can now automatically redirect to the selected folder.
  - Added **Restore Original Paths** for individual imports.
  - Explicit **Import Package > Here...** destinations remain unchanged.
  - Added folder browsing, validation, and clearing controls.

- **Documentation**
  - Updated the README and changelog with setup and behavior details.

- **Bug Fixes**
  - Improved handling of repeated and asynchronous package import windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->